### PR TITLE
Fixed a compiler warning about undefined #define

### DIFF
--- a/lib/tsan/rtl/tsan_defs.h
+++ b/lib/tsan/rtl/tsan_defs.h
@@ -29,7 +29,11 @@
 #endif
 
 #ifndef TSAN_CONTAINS_UBSAN
-# define TSAN_CONTAINS_UBSAN (CAN_SANITIZE_UB && !defined(SANITIZER_GO))
+#  if CAN_SANITIZE_UB && !defined(SANITIZER_GO)
+#    define TSAN_CONTAINS_UBSAN 1
+#  else
+#    define TSAN_CONTAINS_UBSAN 0
+#  endif
 #endif
 
 namespace __tsan {


### PR DESCRIPTION
Complier warns that the result of a macro is undefined. The issue appears to be the use of !defined(SANITIZER_GO) when not in an #if context.
