### PR TITLE
[cmake] Make sure that we propagate down the rpath properly in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,12 +31,18 @@ if(CMAKE_VERSION VERSION_LESS 2.8.12)
   # Invalidate a couple of keywords.
   set(cmake_2_8_12_INTERFACE)
   set(cmake_2_8_12_PRIVATE)
+  if(APPLE)
+    set(CMAKE_MACOSX_RPATH On)
+  endif
 else()
   # Use ${cmake_2_8_12_KEYWORD} intead of KEYWORD in target_link_libraries().
   set(cmake_2_8_12_INTERFACE INTERFACE)
   set(cmake_2_8_12_PRIVATE PRIVATE)
   if(POLICY CMP0022)
     cmake_policy(SET CMP0022 NEW) # automatic when 2.8.12 is required
+  endif()
+  if(POLICY CMP0042)
+    cmake_policy(SET CMP0042 NEW) # automatic when 2.8.12 is required
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ if(CMAKE_VERSION VERSION_LESS 2.8.12)
   set(cmake_2_8_12_PRIVATE)
   if(APPLE)
     set(CMAKE_MACOSX_RPATH On)
-  endif
+  endif()
 else()
   # Use ${cmake_2_8_12_KEYWORD} intead of KEYWORD in target_link_libraries().
   set(cmake_2_8_12_INTERFACE INTERFACE)


### PR DESCRIPTION
This consists of two patches of which the first is actually the meat (and the second one fixes a typo). I am going to squash them into one commit.

What this commit does is default CMAKE_MACOSX_RPATH to be on. These patches have been enabled in LLVM trunk since December and has been used for a while on macOS.

rdar://26055236
