### PR TITLE
Fix for TSan unit-tests:

### DIFF
--- a/lib/tsan/tests/CMakeLists.txt
+++ b/lib/tsan/tests/CMakeLists.txt
@@ -2,7 +2,7 @@ include_directories(../rtl)
 
 add_custom_target(TsanUnitTests)
 set_target_properties(TsanUnitTests PROPERTIES
-  FOLDER "TSan unittests")
+  FOLDER "Compiler-RT Tests")
 
 set(TSAN_UNITTEST_CFLAGS
   ${TSAN_CFLAGS}
@@ -49,9 +49,11 @@ endforeach()
 macro(add_tsan_unittest testname)
   cmake_parse_arguments(TEST "" "" "SOURCES;HEADERS" ${ARGN})
   if(UNIX)
-    foreach(arch ${ASAN_TEST_ARCH})
-      generate_compiler_rt_tests(TsanUnitTests ${testname} ${arch}
-        SOURCES ${TEST_SOURCES}
+    foreach(arch ${TSAN_TEST_ARCH})
+      set(TsanUnitTestsObjects)
+      generate_compiler_rt_tests(TsanUnitTestsObjects TsanUnitTests
+        "${testname}-${arch}-Test" ${arch}
+        SOURCES ${TEST_SOURCES} ${COMPILER_RT_GTEST_SOURCE}
         RUNTIME ${TSAN_TEST_RUNTIME}
         COMPILE_DEPS ${TEST_HEADERS} ${TSAN_RTL_HEADERS}
         DEPS gtest tsan


### PR DESCRIPTION
Previous refactoring has left unit-tests in a buggy state,
where they were not launched at all.

git-svn-id: https://llvm.org/svn/llvm-project/compiler-rt/trunk@312094 91177308-0d34-0410-b5e6-96231b3b80d8