### PR TITLE
Fix for https://bugs.llvm.org/show_bug.cgi?id=37418 and time spec struct redefinition error

### DIFF
--- a/lib/sanitizer_common/sanitizer_common_syscalls.inc
+++ b/lib/sanitizer_common/sanitizer_common_syscalls.inc
@@ -923,16 +923,6 @@ POST_SYSCALL(newfstat)(long res, long fd, void *statbuf) {
   }
 }
 
-#if !SANITIZER_ANDROID
-PRE_SYSCALL(ustat)(long dev, void *ubuf) {}
-
-POST_SYSCALL(ustat)(long res, long dev, void *ubuf) {
-  if (res >= 0) {
-    if (ubuf) POST_WRITE(ubuf, struct_ustat_sz);
-  }
-}
-#endif  // !SANITIZER_ANDROID
-
 PRE_SYSCALL(stat64)(const void *filename, void *statbuf) {
   if (filename)
     PRE_READ(filename,

--- a/lib/sanitizer_common/sanitizer_platform_limits_linux.cc
+++ b/lib/sanitizer_common/sanitizer_platform_limits_linux.cc
@@ -30,6 +30,7 @@
 // fine with newer headers, too.
 #include <linux/posix_types.h>
 #if defined(__x86_64__) ||  defined(__mips__)
+#define _STRUCT_TIMESPEC
 #include <sys/stat.h>
 #else
 #define ino_t __kernel_ino_t

--- a/lib/sanitizer_common/sanitizer_platform_limits_posix.cc
+++ b/lib/sanitizer_common/sanitizer_platform_limits_posix.cc
@@ -159,7 +159,6 @@ typedef struct user_fpregs elf_fpregset_t;
 # include <sys/procfs.h>
 #endif
 #include <sys/user.h>
-#include <sys/ustat.h>
 #include <linux/cyclades.h>
 #include <linux/if_eql.h>
 #include <linux/if_plip.h>
@@ -253,7 +252,6 @@ namespace __sanitizer {
 #endif // SANITIZER_LINUX || SANITIZER_FREEBSD
 
 #if SANITIZER_LINUX && !SANITIZER_ANDROID
-  unsigned struct_ustat_sz = sizeof(struct ustat);
   unsigned struct_rlimit64_sz = sizeof(struct rlimit64);
   unsigned struct_statvfs64_sz = sizeof(struct statvfs64);
 #endif // SANITIZER_LINUX && !SANITIZER_ANDROID

--- a/lib/sanitizer_common/sanitizer_platform_limits_posix.h
+++ b/lib/sanitizer_common/sanitizer_platform_limits_posix.h
@@ -197,7 +197,6 @@ namespace __sanitizer {
     int v[10];
   };
 
-  extern unsigned struct_ustat_sz;
   extern unsigned struct_rlimit64_sz;
   extern unsigned struct_statvfs64_sz;
 


### PR DESCRIPTION
I ran into this issue with the latest version of Fedora and discovered https://bugs.llvm.org/show_bug.cgi?id=37418 had already been filed to remove sys/ustat.h. I checked the use of the structure and it does not seem to have been used for any specific compiler-rt functionality. 