### PR TITLE
Disable running LSan tests on Darwin due the recent changes to the Clang driver

### DIFF
--- a/test/lsan/lit.common.cfg
+++ b/test/lsan/lit.common.cfg
@@ -78,3 +78,8 @@ if re.search('mthumb', config.target_cflags) is not None:
   config.unsupported = True
 
 config.suffixes = ['.c', '.cc', '.cpp', '.mm']
+
+# Apple-Clang: Disable LSan
+if config.host_os == 'Darwin':
+  lit_config.note('Disabling LSan tests on Darwin')
+  config.unsupported = True


### PR DESCRIPTION
Disable running LSan tests on Darwin due the recent changes to the Clang driver to the Clang driver in https://github.com/apple/swift-clang/pull/249.

This is necessary because the standalone LSan tests will be executed
and will fail without this patch when using the newer Clang.

rdar://problem/45841334