### PR TITLE
Disable running LSan tests on Darwin due the recent changes to the Clang driver

### DIFF
--- a/test/lsan/lit.common.cfg
+++ b/test/lsan/lit.common.cfg
@@ -78,3 +78,8 @@ if re.search('mthumb', config.target_cflags) is not None:
   config.unsupported = True
 
 config.suffixes = ['.c', '.cc', '.cpp', '.mm']
+
+# Apple-Clang: Disable LSan
+if config.host_os == 'Darwin':
+  lit_config.note('Disabling LSan tests on Darwin')
+  config.unsupported = True


### PR DESCRIPTION
Cherry-pick #31. DO NOT MERGE until approved.