### PR TITLE
[LibFuzzer] Unbreak `fuzzer/fuzzer-oom.test`.

### DIFF
--- a/test/fuzzer/fuzzer-oom.test
+++ b/test/fuzzer/fuzzer-oom.test
@@ -7,15 +7,15 @@ RUN: %cpp_compiler %S/OutOfMemoryTest.cpp -o %t-OutOfMemoryTest.exe
 RUN: %cpp_compiler %S/OutOfMemorySingleLargeMallocTest.cpp -o %t-OutOfMemorySingleLargeMallocTest.exe
 RUN: %cpp_compiler %S/AccumulateAllocationsTest.cpp -o %t-AccumulateAllocationsTest.exe
 
-RUN: not %run %t-OutOfMemoryTest -rss_limit_mb=300 2>&1 | FileCheck %s
+RUN: not %run %t-OutOfMemoryTest.exe -rss_limit_mb=300 2>&1 | FileCheck %s
 
 CHECK: ERROR: libFuzzer: out-of-memory (used: {{.*}}; limit: 300Mb)
 CHECK: Test unit written to ./oom-
 SUMMARY: libFuzzer: out-of-memory
 
-RUN: not %run %t-OutOfMemorySingleLargeMallocTest -rss_limit_mb=300    2>&1 | FileCheck %s --check-prefix=SINGLE_LARGE_MALLOC
-RUN: not %run %t-OutOfMemorySingleLargeMallocTest -malloc_limit_mb=300 2>&1 | FileCheck %s --check-prefix=SINGLE_LARGE_MALLOC
-RUN: not %run %t-OutOfMemorySingleLargeMallocTest -rss_limit_mb=1000 -malloc_limit_mb=300 2>&1 | FileCheck %s --check-prefix=SINGLE_LARGE_MALLOC
+RUN: not %run %t-OutOfMemorySingleLargeMallocTest.exe -rss_limit_mb=300    2>&1 | FileCheck %s --check-prefix=SINGLE_LARGE_MALLOC
+RUN: not %run %t-OutOfMemorySingleLargeMallocTest.exe -malloc_limit_mb=300 2>&1 | FileCheck %s --check-prefix=SINGLE_LARGE_MALLOC
+RUN: not %run %t-OutOfMemorySingleLargeMallocTest.exe -rss_limit_mb=1000 -malloc_limit_mb=300 2>&1 | FileCheck %s --check-prefix=SINGLE_LARGE_MALLOC
 
 We used to check for "out-of-memory (malloc(53{{.*}}))", but that would fail
 sometimes, so now we accept any OOM message.
@@ -24,4 +24,4 @@ SINGLE_LARGE_MALLOC: libFuzzer: out-of-memory
 SINGLE_LARGE_MALLOC: in LLVMFuzzerTestOneInput
 
 # Check that -rss_limit_mb=0 means no limit.
-RUN: %run %t-AccumulateAllocationsTest -runs=1000 -rss_limit_mb=0
+RUN: %run %t-AccumulateAllocationsTest.exe -runs=1000 -rss_limit_mb=0


### PR DESCRIPTION
The test was compiling binaries with a `.exe` extension but then
tried running them without the extension. On incremental bots we
wouldn't notice the failure because we'd just run existing binaries.

It looks like this might be the result of a bad merge (possibly with
https://reviews.llvm.org/D51735) because
10b49e5094975a1a32ccd160383004ce30e9b4cd (the responsible commit)
doesn't look like https://reviews.llvm.org/D54004 as described in that
commit's description.

rdar://problem/46987680