### PR TITLE
SafeStack: Disable Darwin support

### DIFF
--- a/lib/safestack/CMakeLists.txt
+++ b/lib/safestack/CMakeLists.txt
@@ -6,29 +6,14 @@ include_directories(..)
 
 set(SAFESTACK_CFLAGS ${SANITIZER_COMMON_CFLAGS})
 
-if(APPLE)
-  # Build universal binary on APPLE.
+foreach(arch ${SAFESTACK_SUPPORTED_ARCH})
   add_compiler_rt_runtime(clang_rt.safestack
     STATIC
-    OS osx
-    ARCHS ${SAFESTACK_SUPPORTED_ARCH}
+    ARCHS ${arch}
     SOURCES ${SAFESTACK_SOURCES}
-            $<TARGET_OBJECTS:RTInterception.osx>
-            $<TARGET_OBJECTS:RTSanitizerCommon.osx>
-            $<TARGET_OBJECTS:RTSanitizerCommonNoLibc.osx>
+            $<TARGET_OBJECTS:RTInterception.${arch}>
+            $<TARGET_OBJECTS:RTSanitizerCommon.${arch}>
+            $<TARGET_OBJECTS:RTSanitizerCommonNoLibc.${arch}>
     CFLAGS ${SAFESTACK_CFLAGS}
     PARENT_TARGET safestack)
-else()
-  # Otherwise, build separate libraries for each target.
-  foreach(arch ${SAFESTACK_SUPPORTED_ARCH})
-    add_compiler_rt_runtime(clang_rt.safestack
-      STATIC
-      ARCHS ${arch}
-      SOURCES ${SAFESTACK_SOURCES}
-              $<TARGET_OBJECTS:RTInterception.${arch}>
-              $<TARGET_OBJECTS:RTSanitizerCommon.${arch}>
-              $<TARGET_OBJECTS:RTSanitizerCommonNoLibc.${arch}>
-      CFLAGS ${SAFESTACK_CFLAGS}
-      PARENT_TARGET safestack)
-  endforeach()
-endif()
+endforeach()

--- a/test/safestack/lit.cfg
+++ b/test/safestack/lit.cfg
@@ -18,5 +18,5 @@ config.substitutions.append( ("%clang_safestack ", config.clang + " -O0 -fsaniti
 if config.lto_supported:
   config.substitutions.append((r"%clang_lto_safestack ", ' '.join(config.lto_launch + [config.clang] + config.lto_flags + ['-fsanitize=safe-stack '])))
 
-if config.host_os not in ['Linux', 'FreeBSD', 'Darwin', 'NetBSD']:
+if config.host_os not in ['Linux', 'FreeBSD', 'NetBSD']:
    config.unsupported = True

--- a/test/safestack/pthread.c
+++ b/test/safestack/pthread.c
@@ -1,8 +1,6 @@
 // RUN: %clang_safestack %s -pthread -o %t
 // RUN: %run %t
 
-// XFAIL: darwin
-
 // Test that pthreads receive their own unsafe stack.
 
 #include <stdlib.h>


### PR DESCRIPTION
Cherry-pick of https://reviews.llvm.org/D50718

Summary:
Darwin support does not appear to be used as evidenced by the fact that
the pthread interceptors have never worked and there is no support for
other common threading mechanisms like GCD.

(cherry picked from commit 50edac6c681cc5f47b0b99fb30c5778966e44a95)