### PR TITLE
[4.2] Cherry picking ustat.h deprecation in glibc2.28

### DIFF
--- a/lib/sanitizer_common/sanitizer_platform_limits_posix.cc
+++ b/lib/sanitizer_common/sanitizer_platform_limits_posix.cc
@@ -159,7 +159,6 @@ typedef struct user_fpregs elf_fpregset_t;
 # include <sys/procfs.h>
 #endif
 #include <sys/user.h>
-#include <sys/ustat.h>
 #include <linux/cyclades.h>
 #include <linux/if_eql.h>
 #include <linux/if_plip.h>
@@ -253,7 +252,19 @@ namespace __sanitizer {
 #endif // SANITIZER_LINUX || SANITIZER_FREEBSD
 
 #if SANITIZER_LINUX && !SANITIZER_ANDROID
-  unsigned struct_ustat_sz = sizeof(struct ustat);
+  // Use pre-computed size of struct ustat to avoid <sys/ustat.h> which
+  // has been removed from glibc 2.28.
+#if defined(__aarch64__) || defined(__s390x__) || defined (__mips64) \
+  || defined(__powerpc64__) || defined(__arch64__) || defined(__sparcv9) \
+  || defined(__x86_64__)
+#define SIZEOF_STRUCT_USTAT 32
+#elif defined(__arm__) || defined(__i386__) || defined(__mips__) \
+  || defined(__powerpc__) || defined(__s390__)
+#define SIZEOF_STRUCT_USTAT 20
+#else
+#error Unknown size of struct ustat
+#endif
+  unsigned struct_ustat_sz = SIZEOF_STRUCT_USTAT;
   unsigned struct_rlimit64_sz = sizeof(struct rlimit64);
   unsigned struct_statvfs64_sz = sizeof(struct statvfs64);
 #endif // SANITIZER_LINUX && !SANITIZER_ANDROID


### PR DESCRIPTION
I'm opening a PR since we can't create issues here, this change [cf2478d53ad7071e84c724a986b56fe17f4f4ca7](https://github.com/apple/swift-compiler-rt/commit/521935db9de17ad08748fd050137ac83b7734835) already available in `stable` and in the swift-5 branches, defines the size of the ustat struct directly without importing `ustat.h` that has been removed in glibc-2.28+ (the release used by Ubuntu18.10+).

Feel free to close this PR if compiler-rt is not included among the projects that can be changed for the Linux 4.2.x releases or if only LTS-like releases matter or for any other reason. I'm just opening this since I noticed that the project didn't compile on the latest Ubuntu.