### PR TITLE
Support `ignore_noninstrumented_modules` on Linux 

### DIFF
--- a/lib/sanitizer_common/sanitizer_common.cc
+++ b/lib/sanitizer_common/sanitizer_common.cc
@@ -127,19 +127,20 @@ void RemoveANSIEscapeSequencesFromString(char *str) {
   *z = '\0';
 }
 
-void LoadedModule::set(const char *module_name, uptr base_address) {
+void LoadedModule::set(const char *module_name, uptr base_address,
+                       bool instrumented) {
   clear();
   full_name_ = internal_strdup(module_name);
   base_address_ = base_address;
+  instrumented_ = instrumented;
 }
 
 void LoadedModule::set(const char *module_name, uptr base_address,
                        ModuleArch arch, u8 uuid[kModuleUUIDSize],
                        bool instrumented) {
-  set(module_name, base_address);
+  set(module_name, base_address, instrumented);
   arch_ = arch;
   internal_memcpy(uuid_, uuid, sizeof(uuid_));
-  instrumented_ = instrumented;
 }
 
 void LoadedModule::clear() {

--- a/lib/sanitizer_common/sanitizer_common.h
+++ b/lib/sanitizer_common/sanitizer_common.h
@@ -711,7 +711,8 @@ class LoadedModule {
     internal_memset(uuid_, 0, kModuleUUIDSize);
     ranges_.clear();
   }
-  void set(const char *module_name, uptr base_address);
+  void set(const char *module_name, uptr base_address,
+           bool instrumented = false);
   void set(const char *module_name, uptr base_address, ModuleArch arch,
            u8 uuid[kModuleUUIDSize], bool instrumented);
   void clear();

--- a/lib/sanitizer_common/sanitizer_linux_libcdep.cc
+++ b/lib/sanitizer_common/sanitizer_linux_libcdep.cc
@@ -541,6 +541,126 @@ struct DlIteratePhdrData {
   bool first;
 };
 
+class DynamicSegment {
+  ElfW(Addr) base_addr;
+  size_t symbol_count;
+  ElfW(Sym *) symbol_table;
+  const char *string_table;
+
+ public:
+  DynamicSegment(ElfW(Addr) base_addr, ElfW(Addr) segment_addr)
+      : base_addr(base_addr),
+        symbol_count(0),
+        symbol_table(nullptr),
+        string_table(nullptr) {
+    initialize(segment_addr);
+    CHECK(symbol_count > 0 && symbol_table && string_table);
+  }
+
+  size_t symbolCount() const { return symbol_count; }
+
+  const char *getSymbolName(size_t index) const {
+    auto str_index = symbol_table[index].st_name;
+    return &string_table[str_index];
+  }
+
+ private:
+  // Elf_Addr -> dereferenceable pointer
+  template <typename Type>
+  Type *toPtr(ElfW(Addr) addr_or_offset) const {
+    bool offset = addr_or_offset < base_addr;
+    ElfW(Addr) ptr = offset ? (base_addr + addr_or_offset) : addr_or_offset;
+    return reinterpret_cast<Type *>(ptr);
+  }
+
+  void initialize(ElfW(Addr) segment_addr) {
+    auto *entry = toPtr<ElfW(Dyn)>(segment_addr);
+    for (; entry->d_tag != DT_NULL; entry++) {
+      auto addr = entry->d_un.d_ptr;
+      switch (entry->d_tag) {
+        case DT_HASH:
+          symbol_count = getSymbolCountFromHash(addr);
+          break;
+        case DT_GNU_HASH:
+          // DT_HASH takes precedence over DT_GNU_HASH
+          if (symbol_count > 0)
+            break;
+          symbol_count = getSymbolCountFromGnuHash(addr);
+          break;
+        case DT_SYMTAB:
+          CHECK_EQ(symbol_table, nullptr);
+          symbol_table = toPtr<ElfW(Sym)>(addr);
+          break;
+        case DT_STRTAB:
+          CHECK_EQ(string_table, nullptr);
+          string_table = toPtr<const char>(addr);
+          break;
+      }
+    }
+  }
+
+  size_t getSymbolCountFromHash(ElfW(Addr) hashtable_addr) const {
+    struct ht_header {
+      uint32_t bucket_count;
+      uint32_t chain_count;
+    };
+    return toPtr<ht_header>(hashtable_addr)->chain_count;
+  }
+
+  size_t getSymbolCountFromGnuHash(ElfW(Addr) hashtable_addr) const {
+    struct ht_header {
+      uint32_t bucket_count;
+      uint32_t symoffset;
+      uint32_t bloom_size;
+      uint32_t bloom_shift;
+    };
+    auto header = toPtr<ht_header>(hashtable_addr);
+    auto word_size = FIRST_32_SECOND_64(sizeof(uint32_t), sizeof(uint64_t));
+    auto buckets_addr =
+        hashtable_addr + sizeof(ht_header) + (word_size * header->bloom_size);
+    auto buckets = toPtr<uint32_t>(buckets_addr);
+    auto chains_addr =
+        buckets_addr + (header->bucket_count * sizeof(buckets[0]));
+    auto chains = toPtr<uint32_t>(chains_addr);
+
+    // Locate the chain that handles the largest index bucket.
+    uint32_t last_symbol = 0;
+    for (uint32_t i = 0; i < header->bucket_count; i++) {
+      last_symbol = Max(buckets[i], last_symbol);
+    }
+
+    // Walk the bucket's chain to add the chain length to the total.
+    uint32_t chain_entry;
+    do {
+      chain_entry = chains[last_symbol - header->symoffset];
+      last_symbol++;
+    } while ((chain_entry & 1) == 0);
+
+    return last_symbol;
+  }
+};
+
+static bool IsModuleInstrumented(dl_phdr_info *info) {
+  // Iterate all headers of the library.
+  for (size_t header = 0; header < info->dlpi_phnum; header++) {
+    // We are only interested in dynamic segments.
+    if (info->dlpi_phdr[header].p_type != PT_DYNAMIC)
+      continue;
+
+    auto base_addr = info->dlpi_addr;
+    auto segment_addr = info->dlpi_phdr[header].p_vaddr;
+    DynamicSegment segment(base_addr, segment_addr);
+
+    // Iterate symbol table.
+    for (size_t i = 0; i < segment.symbolCount(); i++) {
+      auto *name = segment.getSymbolName(i);
+      if (internal_strcmp(name, "__tsan_init") == 0)
+        return true;
+    }
+  }
+  return false;
+}
+
 static int dl_iterate_phdr_cb(dl_phdr_info *info, size_t size, void *arg) {
   DlIteratePhdrData *data = (DlIteratePhdrData*)arg;
   InternalScopedString module_name(kMaxPathLength);
@@ -554,7 +674,8 @@ static int dl_iterate_phdr_cb(dl_phdr_info *info, size_t size, void *arg) {
   if (module_name[0] == '\0')
     return 0;
   LoadedModule cur_module;
-  cur_module.set(module_name.data(), info->dlpi_addr);
+  bool instrumented = IsModuleInstrumented(info);
+  cur_module.set(module_name.data(), info->dlpi_addr, instrumented);
   for (int i = 0; i < (int)info->dlpi_phnum; i++) {
     const Elf_Phdr *phdr = &info->dlpi_phdr[i];
     if (phdr->p_type == PT_LOAD) {

--- a/lib/tsan/rtl/tsan_flags.inc
+++ b/lib/tsan/rtl/tsan_flags.inc
@@ -76,7 +76,7 @@ TSAN_FLAG(int, io_sync, 1,
 TSAN_FLAG(bool, die_after_fork, true,
           "Die after multi-threaded fork if the child creates new threads.")
 TSAN_FLAG(const char *, suppressions, "", "Suppressions file name.")
-TSAN_FLAG(bool, ignore_noninstrumented_modules, SANITIZER_MAC ? true : false,
+TSAN_FLAG(bool, ignore_noninstrumented_modules, true,
           "Interceptors should only detect races when called from instrumented "
           "modules.")
 TSAN_FLAG(bool, shared_ptr_interceptor, true,

--- a/test/tsan/ignore-noninstrumented.cc
+++ b/test/tsan/ignore-noninstrumented.cc
@@ -1,9 +1,8 @@
-// Check that ignore_noninstrumented_modules=1 suppresses reporting races from
-// system libraries on OS X. There are currently false positives coming from
-// libxpc, libdispatch, CoreFoundation and others, because these libraries use
-// TSan-invisible atomics as synchronization.
+// Check that ignore_noninstrumented_modules=1 suppresses reports originating
+// from interceptors that are called from an un-instrumented library.
 
-// RUN: %clang_tsan %s -o %t -framework Foundation
+// RUN: %clangxx_tsan %s -fPIC -shared -DLIBRARY -fno-sanitize=thread -o %t.library.so
+// RUN: %clangxx_tsan %s %t.library.so -o %t
 
 // Check that without the flag, there are false positives.
 // RUN: %env_tsan_opts=ignore_noninstrumented_modules=0 %deflake %run %t      2>&1 | FileCheck %s --check-prefix=CHECK-RACE
@@ -14,42 +13,58 @@
 // With ignore_noninstrumented_modules=1, races in user's code are still reported.
 // RUN: %env_tsan_opts=ignore_noninstrumented_modules=1 %deflake %run %t race 2>&1 | FileCheck %s --check-prefix=CHECK-RACE
 
-#import <Foundation/Foundation.h>
+#include "test.h"
 
-#import "../test.h"
+#include <cstring>
 
+#ifdef LIBRARY
+namespace library {
+#endif
 char global_buf[64];
 
 void *Thread1(void *x) {
   barrier_wait(&barrier);
-  strcpy(global_buf, "hello world");
+  strcpy(global_buf, "hello world");  // NOLINT
   return NULL;
 }
 
 void *Thread2(void *x) {
-  strcpy(global_buf, "world hello");
+  strcpy(global_buf, "world hello");  // NOLINT
   barrier_wait(&barrier);
   return NULL;
 }
 
+void Race() {
+  barrier_init(&barrier, 2);
+  pthread_t t[2];
+  pthread_create(&t[0], NULL, Thread1, NULL);
+  pthread_create(&t[1], NULL, Thread2, NULL);
+  pthread_join(t[0], NULL);
+  pthread_join(t[1], NULL);
+}
+#ifdef LIBRARY
+} // namespace library
+#endif
+
+#ifndef LIBRARY
+namespace library {
+  void Race();
+}
+
 int main(int argc, char *argv[]) {
   fprintf(stderr, "Hello world.\n");
-  
-  // NSUserDefaults uses XPC which triggers the false positive.
-  NSDictionary *d = [[NSUserDefaults standardUserDefaults] dictionaryRepresentation];
-  fprintf(stderr, "d = %p\n", d);
 
-  if (argc > 1 && strcmp(argv[1], "race") == 0) {
-    barrier_init(&barrier, 2);
-    pthread_t t[2];
-    pthread_create(&t[0], NULL, Thread1, NULL);
-    pthread_create(&t[1], NULL, Thread2, NULL);
-    pthread_join(t[0], NULL);
-    pthread_join(t[1], NULL);
-  }
+  // Race in un-instrumented library
+  library::Race();
+
+  // Race in user code, if requested
+  if (argc > 1 && strcmp(argv[1], "race") == 0)
+    Race();
 
   fprintf(stderr, "Done.\n");
 }
+
+#endif // LIBRARY
 
 // CHECK: Hello world.
 // CHECK-RACE: SUMMARY: ThreadSanitizer: data race

--- a/test/tsan/libdispatch/lit.local.cfg
+++ b/test/tsan/libdispatch/lit.local.cfg
@@ -13,5 +13,4 @@ if 'libdispatch' in root.available_features:
 else:
   config.unsupported = True
 
-if config.host_os == 'Darwin':
-  config.environment['TSAN_OPTIONS'] += ':ignore_noninstrumented_modules=1'
+config.environment['TSAN_OPTIONS'] += ':ignore_noninstrumented_modules=1'


### PR DESCRIPTION
Land a proposed upstream change so I can continue to make progress on
the Swift side. If the upstream patch changes before it lands, this will
create a merge conflict which I will fix by aligning this change with
whatever we decided to do upstream.

rdar://49176314

Original upstream patch description/commit message:

> We implemented the `ignore_noninstrumented_modules` flag for Darwin [1]
> to be able to use TSan on Darwin, where the "re-compile the world"
> approach is difficult to follow in practice.
> 
> Now we are in the same situation when adding TSan support for Swift on
> Linux.  The libdispatch library is a source of false positives and
> compiling it with TSan (although it is compiled from source on Linux)
> proves to be tricky and insufficient.  The better path seems to be to
> make `ignore_noninstrumented_modules` work on Linux.
> 
> The missing piece with this functionality on Linux is the detection
> whether or not a loaded library is instrumented (which is suprisingly
> difficult).  In this patch we use the ELF segment metadata and symbol
> table to check whether any sanitizer symbols are present.  [2,3] were
> useful resources in the development of this patch (especially,
> `getSymbolCountFromGnuHash`).
> 
> Also enable flag for libdispatch tests on Linux to make them pass. The
> default value for this flag on Linux remains OFF.
> 
> [1]: https://reviews.llvm.org/D28264
> [2]: https://chromium.googlesource.com/crashpad/crashpad/+/1f1657d573c789aa36b6022440e34d9ec30d894c%5E%21/
> [3]: https://flapenguin.me/2017/05/10/elf-lookup-dt-gnu-hash/
> 
> Differential Revision: https://reviews.llvm.org/D61708

Also set ignore_noninstrumented_modules=1 on Linux. This is a
permanent divergence of upstream and Swift's comiler-rt.