### PR TITLE
[TSan] Ensure libc++ can be built for TSan tests on Linux

### DIFF
--- a/lib/tsan/CMakeLists.txt
+++ b/lib/tsan/CMakeLists.txt
@@ -248,7 +248,7 @@ if(COMPILER_RT_LIBCXX_PATH AND
     set(LIBCXX_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/libcxx_tsan_${arch})
     add_custom_libcxx(libcxx_tsan_${arch} ${LIBCXX_PREFIX}
       DEPS ${TSAN_RUNTIME_LIBRARIES}
-      CFLAGS ${TARGET_CFLAGS} -fsanitize=thread
+      CFLAGS ${TARGET_CFLAGS} -fsanitize=thread ${COMPILER_RT_TEST_LIBDISPATCH_CFLAGS}
       USE_TOOLCHAIN)
     list(APPEND libcxx_tsan_deps libcxx_tsan_${arch}-build)
   endforeach()

--- a/test/tsan/libdispatch/sync-block-copy.cc
+++ b/test/tsan/libdispatch/sync-block-copy.cc
@@ -6,6 +6,10 @@
 // RUN: %run %t_no_tsan   2>&1 | FileCheck %s
 // RUN: %run %t_with_tsan 2>&1 | FileCheck %s --implicit-check-not='ThreadSanitizer'
 
+// On Linux, requires upstream changes for how libc++ is built under TSan, which
+// aren't included in the swift-5.1-branch.
+// XFAIL: linux
+
 #include <dispatch/dispatch.h>
 
 #include <stdio.h>


### PR DESCRIPTION
Required change to make "Swift CI preset for LLVM libdispatch tests" [1]
work.

This goes the opposite direction of [2, 3], ensuring that the link step
succeeds for the produced dynamic library (*.so). In the future versions
of compiler-rt this will not be necessary since we will create a static
archive instead.

[1] https://github.com/apple/swift/pull/24330
[2] https://reviews.llvm.org/D58013
[3] https://reviews.llvm.org/rG0a9cb239a6c91a709a98c96bbf60b6c006d5a07b

rdar://problem/50828689