### PR TITLE
[TSan] Turn on ignore_interceptors_accesses

### DIFF
--- a/lib/tsan/rtl/tsan_flags.inc
+++ b/lib/tsan/rtl/tsan_flags.inc
@@ -77,7 +77,7 @@ TSAN_FLAG(int, io_sync, 1,
 TSAN_FLAG(bool, die_after_fork, true,
           "Die after multi-threaded fork if the child creates new threads.")
 TSAN_FLAG(const char *, suppressions, "", "Suppressions file name.")
-TSAN_FLAG(bool, ignore_interceptors_accesses, false,
+TSAN_FLAG(bool, ignore_interceptors_accesses, true,
           "Ignore reads and writes from all interceptors.")
 TSAN_FLAG(bool, ignore_noninstrumented_modules, true,
           "Interceptors should only detect races when called from instrumented "


### PR DESCRIPTION
This flag is usually enabled on Darwin. Turn it on unconditionally for
Swift, even on Linux.

Reason: Silences the remaining false positives for TSan in the swift-nio
test suite.

rdar://52215193